### PR TITLE
Fix typo in Storage Service environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ environment variables
 ARCHIVEMATICA_DASHBOARD_DASHBOARD_AUDIT_LOG_MIDDLEWARE: "true"
 
 # Storage Service 0.18+
-SS_AUTH_LOG_MIDDLEWARE: "true"
+SS_AUDIT_LOG_MIDDLEWARE: "true"
 ```
 
 2. Restart Archivematica and Storage Service services


### PR DESCRIPTION
This PR corrects a typo in the instructions for enabling audit logging middleware in the Storage Service spotted by @scollazo.